### PR TITLE
Include support for all Ruby versions that did not reach EOL.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.1.6'
+          - '3.2.4'
           - '3.3.0'
 
     steps:

--- a/mistral.gemspec
+++ b/mistral.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = 'A 1:1 Ruby port of the official Mistral Python client, with feature and API parity.'
   spec.homepage = 'https://github.com/wilsonsilva/mistral'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 3.3.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 


### PR DESCRIPTION
Atm, this include ruby 3.1 and up which should be helpful for people that have something
preventing them from upgrading immediately to latest ruby version.
